### PR TITLE
Upgrade nodemailer from 8.0.1 to 9.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soajs.core.modules",
   "description": "SOAJS core modules package",
-  "version": "5.2.19",
+  "version": "5.2.20",
   "author": {
     "name": "soajs team",
     "email": "team@soajs.org"
@@ -50,7 +50,7 @@
     "install": "0.13.0",
     "jsonschema": "1.5.0",
     "mongodb": "7.5.0",
-    "nodemailer": "8.0.1",
+    "nodemailer": "9.0.3",
     "object-hash": "3.0.0",
     "soajs.core.libs": "1.2.2"
   }


### PR DESCRIPTION
## Breaking change in 9.0.0, and why it does not affect us

HTTPS requests now validate the server's TLS certificate by default. Reading the 9.0.3 source, this covers exactly three call sites:

- `lib/fetch/index.js` — remote content for attachment `href`/`path` **URLs**
- `lib/xoauth2/index.js` — OAuth2 token endpoints
- `lib/smtp-connection/http-proxy-client.js` — HTTP/HTTPS proxy `CONNECT`

None are on a soajs code path. We do not use attachments with URLs, xoauth2, or a proxy, and `rejectUnauthorized` is not set anywhere in this repo, soajs.mailer, or soajs.urac.

**This is not a change to SMTP server TLS validation** — that is a separate socket path and is unchanged, so existing `ignoreTLS`/`secure` SMTP configs behave the same.

## Consumers

Only two files require nodemailer: `soajs.core/mail/index.js` (`createTransport` + `sendMail`) and `soajs.mail/` layered on it. Both use the stable core API.

## Also picked up

We were pinned exactly on `8.0.1`, so this also brings in 8.0.2 through 8.0.11:

- STARTTLS upgrade and secure socket handling hardened (9.0.3)
- CRLF rejected in proxy `CONNECT` destinations, preventing request injection (9.0.2)
- smtp-connection response parsing and socket lifecycle hardening (9.0.2)
- `addressparser` fix for operator chars inside address literals (9.0.2)
- ReDoS fix in Ethereal response parsing (8.0.11)

nodemailer has **zero** dependencies on both versions, so nothing else moves. Engines are `node >=6.0.0` on both.

## Verified locally

Against a local Mongo 8.2.0:

- `test/unit/core.email.test.js` — 14/14 on 8.0.1, then 14/14 identical on 9.0.3
- full unit suite (`test/unit/_servers.test.js`) — **172 passing, 2 pending, 0 failing** on 9.0.3

Note the full suite needs `--exit` to terminate; without it mocha hangs on open mongo handles after the tests have already passed. Pre-existing, unrelated to this change.

## One caveat for downstream

`soajs.mail`'s attachment schema allows an attachment `path`, and nodemailer treats a URL there as remote content. Nothing in the soajs repos passes one, but a downstream consumer passing an HTTPS URL to a host with a self-signed or expired cert would now fail. Opt-out is a per-attachment `tls: { rejectUnauthorized: false }`.

Version bumped to 5.2.20 — 5.2.19 is published and the dependency updates in 20144ac are still unreleased, so they ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)